### PR TITLE
Add handling for associative arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Gemfile.lock
 .vagrant
 .idea
 spec/support/custom_config.rb
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ install:
 language: ruby
 rvm:
   - 2.5.0
+  - jruby-9.1.15.0
   - 2.4.3
   - 2.3.6
   - 2.2.9
-  - jruby-9.1.15.0
   - ruby-head
   - jruby-head
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/rsim/ruby-plsql.svg?branch=master)](https://travis-ci.org/rsim/ruby-plsql)
+[![Build Status](https://travis-ci.org/edthamm/ruby-plsql.svg?branch=master)](https://travis-ci.org/edthamm/ruby-plsql)
 
 ruby-plsql
 ==========

--- a/lib/plsql/procedure.rb
+++ b/lib/plsql/procedure.rb
@@ -241,7 +241,7 @@ module PLSQL
 
     def determine_index_type(type_name)
       begin
-        index_type = @schema.select_one("SELECT type FROM sys.dba_identifiers WHERE name = '#{type_name}' and usage = 'DECLARATION'")
+        index_type = @schema.select_one("SELECT type FROM sys.all_identifiers WHERE name = '#{type_name}' and usage = 'DECLARATION'")
         return ",\ni__ VARCHAR2(4000)\n" if index_type == "ASSOCIATIVE ARRAY"
         ",\ni__ NUMBER(38)\n"
       rescue # no matter what fails preserve previous behavior

--- a/lib/plsql/procedure.rb
+++ b/lib/plsql/procedure.rb
@@ -240,9 +240,13 @@ module PLSQL
     end
 
     def determine_index_type(type_name)
-      index_type = @schema.select_one("SELECT type FROM sys.dba_identifiers WHERE name = '#{type_name}' and usage = 'DECLARATION'")
-      return ",\ni__ VARCHAR2(4000)\n" if index_type == "ASSOCIATIVE ARRAY"
-      ",\ni__ NUMBER(38)\n"
+      begin
+        index_type = @schema.select_one("SELECT type FROM sys.dba_identifiers WHERE name = '#{type_name}' and usage = 'DECLARATION'")
+        return ",\ni__ VARCHAR2(4000)\n" if index_type == "ASSOCIATIVE ARRAY"
+        ",\ni__ NUMBER(38)\n"
+      rescue OCIError
+        ",\ni__ NUMBER(38)\n"
+      end
     end
 
     def overloaded? #:nodoc:

--- a/lib/plsql/procedure.rb
+++ b/lib/plsql/procedure.rb
@@ -244,7 +244,7 @@ module PLSQL
         index_type = @schema.select_one("SELECT type FROM sys.dba_identifiers WHERE name = '#{type_name}' and usage = 'DECLARATION'")
         return ",\ni__ VARCHAR2(4000)\n" if index_type == "ASSOCIATIVE ARRAY"
         ",\ni__ NUMBER(38)\n"
-      rescue OCIError
+      rescue # no matter what fails preserve previous behavior
         ",\ni__ NUMBER(38)\n"
       end
     end


### PR DESCRIPTION
Check type of index via proxy in all_identifiers.
Set index of temporary table accordingly.
Not the most pretty solution but working none the less